### PR TITLE
chore: Add new rules to lint. Fix typo in board model

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "plugins": ["react", "jest"],
   "rules": {
     "import/prefer-default-export": 0,
+    "no-underscore-dangle": 0,
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",

--- a/server/models/board.js
+++ b/server/models/board.js
@@ -28,7 +28,7 @@ const BoardSchema = new Schema(
         },
       },
     ],
-    lifeCycles: [
+    lifecycles: [
       {
         type: Schema.Types.ObjectId,
         ref: 'Lifecycle',


### PR DESCRIPTION
ESLint gives an error when using object properties that start with an underscore. This creates a problem while working with MongoDB data since the Object ID property assigned by Mongo is `_id`.
Disabling `no-underscore-dangle` check fixes this.

Resolves #90 