### PR TITLE
Use userid from authentication system

### DIFF
--- a/server/routes/issues.js
+++ b/server/routes/issues.js
@@ -14,6 +14,7 @@ const router = express.Router();
 async function setAttribute(req, res) {
   const { issueid } = req.params;
   const { attributeName, attributeValue } = req.body;
+  const modifiedBy = '5d017f092d047389ea99ac9f'; // TODO: Remove hard coded value  to req.user.id when cors issue is solved
 
   const isIssueIdValid = mongoose.Types.ObjectId.isValid(issueid);
   if (!isIssueIdValid) {
@@ -24,10 +25,10 @@ async function setAttribute(req, res) {
   const attributeObject = {};
   if (attributeValue === null) {
     attributeObject[attributeName] = '';
-    updateObject = { $unset: attributeObject };
+    updateObject = { $unset: attributeObject, $set: { modifiedBy } };
   } else {
     attributeObject[attributeName] = attributeValue;
-    updateObject = { $set: attributeObject };
+    updateObject = { $set: { ...attributeObject, modifiedBy } };
   }
 
   let savedIssue;
@@ -74,13 +75,13 @@ router.get('/:issueid', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const { lifecycleid, issue, createdBy } = req.body;
+  const { lifecycleid, issue } = req.body;
+  const createdBy = '5d017f092d047389ea99ac9f'; // TODO: Remove hard coded value  to req.user.id when cors issue is solved
 
   const isLifecycleIdValid = mongoose.Types.ObjectId.isValid(lifecycleid);
-  const isCreatedByValid = mongoose.Types.ObjectId.isValid(createdBy);
 
-  if (!isLifecycleIdValid || !issue || !isCreatedByValid) {
-    return res.status(BAD_REQUEST).send('Invalid lifecycleid, issue or createdBy field');
+  if (!isLifecycleIdValid || !issue) {
+    return res.status(BAD_REQUEST).send('Invalid lifecycleid or issue');
   }
 
   const issueDocument = { issue, createdBy };
@@ -124,12 +125,12 @@ router.patch(
 
 router.post('/:issueid/comment', async (req, res) => {
   const { issueid } = req.params;
-  const { comment, commentedBy } = req.body;
+  const { comment } = req.body;
+  const commentedBy = '5d017f092d047389ea99ac9f'; // TODO: Remove hard coded value  to req.user.id when cors issue is solved
 
-  const isCommentedByValid = mongoose.Types.ObjectId.isValid(commentedBy);
   const isIssueIdValid = mongoose.Types.ObjectId.isValid(issueid);
-  if (!isCommentedByValid || !isIssueIdValid || !comment) {
-    return res.status(BAD_REQUEST).send('Invalid issueid, commentedBy or comment');
+  if (!isIssueIdValid || !comment) {
+    return res.status(BAD_REQUEST).send('Invalid issueid or comment');
   }
 
   let savedIssue;

--- a/server/routes/issues.test.js
+++ b/server/routes/issues.test.js
@@ -24,27 +24,17 @@ describe('URL/issues routes', () => {
         .expect(BAD_REQUEST, done);
     });
 
-    test('should return 400 if issue or createdBy fields are not sent', (done) => {
+    test('should return 400 if issue is not sent', (done) => {
       request(server)
         .post('/issues')
         .send({ lifecycleid: '123456789abc' })
         .expect(BAD_REQUEST, done);
-
-      request(server)
-        .post('/issues')
-        .send({ lifecycleid: '123456789abc', issue: 'A new issue' })
-        .expect(BAD_REQUEST, done);
-
-      request(server)
-        .post('/issues')
-        .send({ lifecycleid: '123456789abc', createdBy: '1234567890ab' })
-        .expect(BAD_REQUEST, done);
     });
 
-    test('should receive 200 if all three parameters are sent', (done) => {
+    test('should receive 200 if all parameters are sent', (done) => {
       const IssueMock = sinon.mock(Issue);
       IssueMock.expects('create')
-        .withArgs({ issue: 'A new issue', createdBy: '1234567890ab' })
+        .withArgs({ issue: 'A new issue' })
         .resolves({ issue: 'A new issue' });
 
       const LifecycleMock = sinon.mock(Lifecycle);
@@ -54,7 +44,7 @@ describe('URL/issues routes', () => {
 
       request(server)
         .post('/issues')
-        .send({ lifecycleid: '123456789abc', issue: 'A new issue', createdBy: '1234567890ab' })
+        .send({ lifecycleid: '123456789abc', issue: 'A new issue' })
         .expect(OK)
         .end(() => {
           LifecycleMock.restore();
@@ -209,29 +199,23 @@ describe('URL/issues routes', () => {
   });
 
   describe('POST /issues/:issueid/comment', () => {
-    test('should return 400 if comment or commentedBy fields are not sent', (done) => {
+    test('should return 400 if comment is not sent', (done) => {
       request(server)
         .post('/issues/5cfb0915a8e23e5b65d10725/comment')
-        .send({ commentedBy: '123456789abc' })
-        .expect(BAD_REQUEST, done);
-
-      request(server)
-        .post('/issues/5cfb0915a8e23e5b65d10725/comment')
-        .send({ comment: 'A comment' })
         .expect(BAD_REQUEST, done);
     });
 
     test('should return 400 if issueid is not valid', (done) => {
       request(server)
         .post('/issues/abcd/comment')
-        .send({ comment: 'A comment', commentedBy: '123456789abc' })
+        .send({ comment: 'A comment' })
         .expect(BAD_REQUEST, done);
     });
 
     test('should receive 200 if all three parameters are sent', (done) => {
       const CommentMock = sinon.mock(Comment);
       CommentMock.expects('create')
-        .withArgs({ comment: 'A comment', commentedBy: '1234567890ab' })
+        .withArgs({ comment: 'A comment' })
         .resolves({ issue: 'Updated issue with a comment' });
 
       const IssueMock = sinon.mock(Lifecycle);
@@ -241,7 +225,7 @@ describe('URL/issues routes', () => {
 
       request(server)
         .post('/issues/5cfb0915a8e23e5b65d10725/comment')
-        .send({ comment: 'A comment', commentedBy: '123456789abc' })
+        .send({ comment: 'A comment' })
         .expect(OK)
         .end(() => {
           CommentMock.restore();


### PR DESCRIPTION
Resolves #123 

This code has hard-coded values for req.user.id because we are facing issues with CORS and passport. Passport is not attaching any data to req.user which is causing the APIs to crash. 

As a temporary workaround, I've used hard-coded values which will be resolved later when the actual issue is fixed.

